### PR TITLE
Remove binder subdir

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "binder"]
-	path = binder
-	url = https://github.com/malariagen/binder.git

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,118 @@
+name: malariagen
+channels:
+  - defaults
+  - pyviz/label/dev
+  - bokeh/label/dev
+  - intake
+  - bioconda
+  - conda-forge
+dependencies:
+  - nomkl
+  - python=3.6
+  - bcftools=1.9
+  - bcolz=1.2.1
+  - biopython=1.72
+  - bokeh=1.0.2
+  - bqplot=0.11.2
+  - cartopy=0.17.0
+  - cython=0.29.2
+  - cytoolz=0.9.0.1
+  - dask=1.0.0
+  # disable dask-ml for now, version incompatible with hmmlearn due to 
+  # dependency conflict on scikit-learn
+  # - dask-ml=0.11.0
+  - distributed=1.25.1
+  - fastcluster=1.1.25
+  - fastparquet=0.2.1
+  - gcsfs=0.2.0
+  - graphviz=2.40.1
+  - h5py=2.8.0
+  - hmmlearn=0.2.0
+  - holoviews=1.10.9
+  - htslib=1.9
+  - humanize=0.5.1
+  - intake-xarray=0.2.4
+  - intervaltree=2.1.0
+  - ipykernel=5.1.0
+  - ipython=7.2.0
+  # disable for now, not compatible with xarray 0.11.0
+  # - ipyleaflet=0.9.2
+  - ipywidgets=7.4.2
+  - joblib=0.13.0
+  - jupyter=1.0.0
+  - jupyter_console=6.0.0
+  - jupyter_client=5.2.4
+  # N.B. jupyterhub versions need to match hub image
+  # https://repo2docker.readthedocs.io/en/latest/howto/jupyterhub_images.html
+  - jupyterhub==0.9.4
+  - jupyterlab=0.35.4
+  - jupyterlab_launcher=0.13.1
+  - lmfit=0.9.11
+  - matplotlib=3.0.2
+  - matplotlib-venn=0.11.5
+  - msgpack-python=0.6.0
+  - msprime=0.6.1
+  - mysqlclient=1.3.14
+  - nb_conda_kernels=2.2.0
+  - nbconvert=5.4.0
+  - nodejs=10.13.0
+  - nose=1.3.7
+  - notebook=5.7.4
+  - numba=0.41.0
+  - numcodecs=0.6.2
+  - numexpr=2.6.8
+  - numpy=1.15.4
+  - openpyxl=2.5.12
+  - pandas=0.23.4
+  - peakutils=1.3.0
+  - petl=1.2.0
+  - pillow=5.3.0
+  - psutil=5.4.8
+  - pyfasta=0.5.2
+  - pyfaidx=0.5.5.2
+  - pytables=3.4.4
+  - python-blosc=1.6.2
+  - pyvcf=0.6.8
+  - pyzmq=17.1.2
+  - qtconsole=4.4.3
+  - s3fs=0.2.0
+  - samtools=1.9
+  - scikit-allel=1.2.0
+  - scikit-image=0.14.1
+  - scikit-learn=0.19.2
+  - scipy=1.1.0
+  - seaborn=0.9.0
+  - snakemake=5.3.1
+  - toolz=0.9.0
+  - tornado=5.1.1
+  - xarray=0.11.0
+  - xlrd=1.2.0
+  - xlwt=1.3.0
+  - zict=0.1.3
+  - pip:
+    # version discrepancy for pysam on bioconda, install from pypi to be sure
+    - pysam==0.15.1
+    - pysamstats==1.1.2
+    # not on conda-forge
+    - anhima==0.11.2
+    # not on conda-forge
+    - prettypandas==0.0.4
+    # version not on conda-forge
+    - graphviz==0.10.1
+    # not build for Python 3.6 on conda-forge
+    - petlx==1.0.3
+    # not on conda-forge
+    - scikits.bootstrap==1.0.0-pypi2
+    # others
+    - Sphinx==1.8.2
+    - sphinx-autobuild==0.7.1
+    - sphinx-bootstrap-theme==0.6.5
+    # others from pangeo
+    - fusepy==3.0.1
+    - click==7.0
+    - jedi==0.13.2
+    - kubernetes==8.0.0
+    - dask-kubernetes==0.6.0
+    - nbserverproxy==0.8.8
+    # pre-release zarr, to get consolidated metadata feature
+    - git+https://github.com/zarr-developers/zarr@2c1a6e09f729547d87a9f5b3fb5592706e01e64d

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,8 @@
+#!/bin/bash
+jupyter serverextension enable --py nbserverproxy --sys-prefix
+jupyter labextension install @jupyter-widgets/jupyterlab-manager \
+                             @jupyterlab/hub-extension \
+                             @pyviz/jupyterlab_pyviz \
+                             dask-labextension
+
+#EOF

--- a/start
+++ b/start
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+export DASK_KUBERNETES__WORKER_TEMPLATE_PATH=${PWD}/.dask/config.yaml
+export DASK_KUBERNETES__WORKER_NAME=dask-{JUPYTERHUB_USER}-{uuid}
+
+
+# set worker image url in worker template
+if [[ -z "${JUPYTER_IMAGE_SPEC}" ]]; then
+    echo "JUPYTER_IMAGE_SPEC is not set"
+else
+  sed -i -e "s|WORKER_IMAGE|${JUPYTER_IMAGE_SPEC}|g" ${DASK_KUBERNETES__WORKER_TEMPLATE_PATH}
+fi
+
+exec "$@"


### PR DESCRIPTION
To work around current issues that seem to be related to use of a "binder" subdirectory, this PR removes use of the malariagen/binder submodule and copies the necessary files up to the root directory of this repo.